### PR TITLE
Add TLE.from_orbit and tle.to_lines functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ n=15.50437522, rev_num=18780)
 
 and you can then access its attributes like `t.argp`, `t.epoch`...
 
+TLE can also be written out to a string based on the orbital value:
+```python
+print(tle.to_lines())
+```
+
 ### TLE format specification
 
 Some more or less complete TLE format specifications can be found on the following websites:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,20 @@ def tle_string():
 2 25544  51.6464 320.1755 0007999  10.9066  53.2893 15.50437522187805"""
 
 @pytest.fixture
+def tle_from_lines_to_lines_expected_string():
+    # expected result of tle = TLE.from_lines(*tle_lines).to_lines()
+    return """ISS (ZARYA)
+1 25544U 98067A   19249.04864348 +.00001909 +00000-0 +40858-4 0  9990
+2 25544  51.6464 320.1755 0007999  10.9066  53.2893 15.50437522187805"""
+
+@pytest.fixture
+def tle_from_orbit_to_lines_expected_string():
+    # expected result of tle = TLE.from_lines(*tle_lines).to_lines()
+    return """ISS (ZARYA)
+1 25544U 98067A   19249.04864348 +.00001909 +00000-0 +40858-4 0  9990
+2 25544  51.6464 320.1755 0007999  10.9066  53.2893 15.50437522187805"""
+
+@pytest.fixture
 def tle_string2():
     # This TLE tests high mean anomaly value.
     return """NOAA 18
@@ -17,12 +31,30 @@ def tle_string2():
 2 28654  99.0522 154.2797 0015184  73.2195 287.0641 14.12501077766909"""
 
 @pytest.fixture
+def tle_strings2_from_orbit_expected():
+    return """NOAA 18
+1 28654U 05018A   20098.54037539 +.00000075 +00000-0 +65128-4 0  9992
+2 28654  99.0522 154.2797 0015184  73.2195 287.0641 14.12501077766909"""
+
+@pytest.fixture
 def tle_lines(tle_string):
     return tle_string.splitlines()
 
 @pytest.fixture
+def tle_from_lines_to_lines_expected(tle_from_lines_to_lines_expected_string):
+    return tle_from_lines_to_lines_expected_string.splitlines()
+
+@pytest.fixture
+def tle_from_orbit_to_lines_expected(tle_from_orbit_to_lines_expected_string):
+    return tle_from_orbit_to_lines_expected_string.splitlines()
+
+@pytest.fixture
 def tle_lines2(tle_string2):
     return tle_string2.splitlines()
+
+@pytest.fixture
+def tle_lines2_from_orbit_expected(tle_strings2_from_orbit_expected):
+    return tle_strings2_from_orbit_expected.splitlines()
 
 @pytest.fixture
 def tle():

--- a/tests/test_tle.py
+++ b/tests/test_tle.py
@@ -3,13 +3,16 @@ from tletools.tle import TLEu
 
 import astropy.units as u
 
+
 def test_from_lines(tle_lines):
     t = TLE.from_lines(*tle_lines)
     assert isinstance(t, TLE)
 
+
 def test_from_lines_high_M(tle_lines2):
     t = TLE.from_lines(*tle_lines2)
     assert isinstance(t, TLE)
+
 
 def test_from_lines_with_units(tle_lines):
     t = TLEu.from_lines(*tle_lines)
@@ -28,8 +31,46 @@ def test_asdict(tle):
 def test_astuple(tle):
     assert type(tle)(*tle.astuple()) == tle
 
-def test_to_lines(tle_lines):
+
+def test_to_lines(tle_lines, tle_from_lines_to_lines_expected):
     t = TLE.from_lines(*tle_lines)
     lines = t.to_lines()
     tle_joined_lines = '\n'.join(tle_lines)
-    assert(lines == tle_joined_lines)
+    assert (lines == tle_from_lines_to_lines_expected)
+
+def test_orbit_to_lines(tle_lines, tle_from_orbit_to_lines_expected):
+    tle = TLE.from_lines(*tle_lines)
+    orbit = tle.to_orbit()
+    # lines = orbit.to_lines()
+
+    lines_from_orbit = TLE.from_orbit(
+        orbit,
+        name=tle.name,
+        int_desig=tle.int_desig,
+        classification=tle.classification,
+        norad=tle.norad,
+        dn_o2=tle.dn_o2,
+        ddn_o6=tle.ddn_o6,
+        bstar=tle.bstar,
+        rev_num=tle.rev_num,
+    ).to_lines()
+    assert lines_from_orbit == tle_from_orbit_to_lines_expected
+
+
+def test_from_orbit_to_lines2(tle_lines2, tle_lines2_from_orbit_expected):
+    tle = TLE.from_lines(*tle_lines2)
+    orbit = tle.to_orbit()
+    # lines = orbit.to_lines()
+
+    lines_from_orbit = TLE.from_orbit(
+        orbit,
+        name=tle.name,
+        int_desig=tle.int_desig,
+        classification=tle.classification,
+        norad=tle.norad,
+        dn_o2=tle.dn_o2,
+        ddn_o6=tle.ddn_o6,
+        bstar=tle.bstar,
+        rev_num=tle.rev_num,
+    ).to_lines()
+    assert tle_lines2_from_orbit_expected == lines_from_orbit

--- a/tests/test_tle.py
+++ b/tests/test_tle.py
@@ -27,3 +27,9 @@ def test_asdict(tle):
 
 def test_astuple(tle):
     assert type(tle)(*tle.astuple()) == tle
+
+def test_to_lines(tle_lines):
+    t = TLE.from_lines(*tle_lines)
+    lines = t.to_lines()
+    tle_joined_lines = '\n'.join(tle_lines)
+    assert(lines == tle_joined_lines)

--- a/tletools/tle.py
+++ b/tletools/tle.py
@@ -297,12 +297,14 @@ class TLE:
         ...     bstar=0.0,
         ...     set_num=999,
         ...     rev_num=999
-        )
-        >>> tle_string = tle.to_lines()
+        ... )
+        >>> tle_lines = tle.to_lines()
+        >>> tle_string = "\n".join(tle_lines)
         >>> tle_string = """UNASSIGNED
         ... 1 00000U 00000A   24032.00000000 +.00001909 +00000-0 +40858-4 0  9999
         ... 2 00000  51.6464 320.1755 0007999  10.9066  53.2158 15.52351307009990"""
         '''
+
         mean_motion = orbit.n * (24 * 60 * 60 * u.s)
         mean_motion = mean_motion / ((2 * np.pi) << u.rad)
         mean_motion = mean_motion.value

--- a/tletools/utils.py
+++ b/tletools/utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 import astropy.units as u
-from poliastro.core.angles import M_to_E as _M_to_E, E_to_nu as _E_to_nu
+from poliastro.core.angles import M_to_E as _M_to_E, E_to_nu as _E_to_nu, nu_to_E as _nu_to_E, E_to_M as _E_to_M
 
 #: :class:`numpy.dtype` for a date expressed as a year.
 dt_dt64_Y = np.dtype('datetime64[Y]')
@@ -17,6 +17,18 @@ rev = u.def_unit(
 
 u.add_enabled_units(rev)
 
+def nu_to_M(nu, ecc):
+    """Mean anomaly from true anomaly.
+    :param float nu: True anomaly in radians.
+    :param float ecc: Eccentricity.
+    :returns: `M`, the mean anomaly, between -π and π radians.
+
+    **Warning**
+
+    The mean anomaly must be between -π and π radians.
+    The eccentricity must be less than 1.
+    """
+    return _E_to_M(_nu_to_E(nu, ecc), ecc)
 
 def M_to_nu(M, ecc):
     """True anomaly from mean anomaly.


### PR DESCRIPTION
Your original TLE functions are very useful, but I believe this function pair could extend its usability:

TLE.from_orbit() and tle.to_lines()

They are useful for us to ingest a orbit through TLE, do some manipulation, such as deltaV, then write out the TLE for downstream processing